### PR TITLE
Story 8807 abstract escalate interface

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in escalate.gemspec
 gemspec
 
+gem "contextual_logger"
+
 gem "pry"
 gem "pry-byebug"
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,8 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in escalate.gemspec
 gemspec
 
+gem "pry"
+gem "pry-byebug"
+
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    escalate (0.1.0)
+    escalate (0.1.0.pre.1)
       activesupport
       contextual_logger
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     escalate (0.1.0.pre.1)
       activesupport
-      contextual_logger
 
 GEM
   remote: https://rubygems.org/
@@ -53,6 +52,7 @@ PLATFORMS
   x86_64-darwin-19
 
 DEPENDENCIES
+  contextual_logger
   escalate!
   pry
   pry-byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,58 @@
+PATH
+  remote: .
+  specs:
+    escalate (0.1.0)
+      activesupport
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.2.4.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.8)
+    diff-lcs (1.4.4)
+    i18n (1.8.7)
+      concurrent-ruby (~> 1.0)
+    method_source (1.0.0)
+    minitest (5.14.3)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    rake (13.0.3)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.9)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  x86_64-darwin-19
+
+DEPENDENCIES
+  escalate!
+  pry
+  pry-byebug
+  rake (~> 13.0)
+  rspec (~> 3.0)
+
+BUNDLED WITH
+   2.2.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     escalate (0.1.0)
       activesupport
+      contextual_logger
 
 GEM
   remote: https://rubygems.org/
@@ -15,9 +16,13 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
+    contextual_logger (0.11.0)
+      activesupport
+      json
     diff-lcs (1.4.4)
     i18n (1.8.7)
       concurrent-ruby (~> 1.0)
+    json (2.5.1)
     method_source (1.0.0)
     minitest (5.14.3)
     pry (0.13.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    escalate (0.1.0.pre.1)
+    escalate (0.1.0.pre.2)
       activesupport
 
 GEM

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Escalate
 
-A simple and lightweight gem to help with escalating errors
+A simple and lightweight gem to escalate rescued exceptions. This implementation
+is an abstract interface that can be used on it's own, or attached to more concrete
+implementations like Honeybadger, Airbrake, or Sentry in order to not just log
+exceptions in an easy to parse way, but also escalate the appropriate information
+to third party systems.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Escalate
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/escalate`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+A simple and lightweight gem to help with escalating errors
 
 ## Installation
 
@@ -22,8 +20,42 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+### Adding Escalate to Your Gem
 
+All you need to do is extend `Escalate.mixin` within your gem and you're all set.
+
+```ruby
+module SomeGem
+  extend Escalate.mixin
+end
+```
+
+This will expose the `Escalate#ex_escalate` method within your gem to be used instead
+of using `logger.error`.
+
+```ruby
+module SomeGem
+  extend Escalate.mixin
+
+  class << self
+    attr_accessor :logger
+  end
+
+  class SomeClass
+    def something_dangerous
+      # ...
+    rescue => ex
+      SomeGem.escalate(ex, "I was doing something dangerous and an exception was raised")
+    end
+  end
+end
+```
+
+When `SomeGem.escalate` above is triggered, it will use the logger returned by `SomeGem.logger` or
+default to a `STDERR` logger and do the following:
+
+1. Log an error containing the exception and any additional information about the current environment that is specified
+2. Trigger any `escalation_callbacks` configured on the `Escalate` gem
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
@@ -32,4 +64,4 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/escalate.
+Bug reports and pull requests are welcome on GitHub at https://github.com/invoca/escalate.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ module SomeGem
 end
 ```
 
-This will expose the `Escalate#ex_escalate` method within your gem to be used instead
+This will expose the `Escalate#escalate` method within your gem to be used instead
 of using `logger.error`.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ All you need to do is extend `Escalate.mixin` within your gem and you're all set
 
 ```ruby
 module SomeGem
-  extend Escalate.mixin
+  include Escalate.mixin
 end
 ```
 
@@ -35,7 +35,7 @@ of using `logger.error`.
 
 ```ruby
 module SomeGem
-  extend Escalate.mixin
+  include Escalate.mixin
 
   class << self
     attr_accessor :logger

--- a/escalate.gemspec
+++ b/escalate.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
   spec.metadata = {
-    "allowed_push_host" => "https://rubygems.com",
+    "allowed_push_host" => "https://rubygems.org",
     "homepage_uri"      => spec.homepage,
     "changelog_uri"     => "#{spec.homepage}/blob/main/CHANGELOG.md"
   }

--- a/escalate.gemspec
+++ b/escalate.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport"
+  spec.add_dependency "contextual_logger"
 end

--- a/escalate.gemspec
+++ b/escalate.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Invoca Development", "Octothorp"]
   spec.email         = ["development@invoca.com", "octothorp@invoca.com"]
 
-  spec.summary       = "Simple gem for abstracting log escalations"
-  spec.description   = "Simple gem for abstracting log escalations"
+  spec.summary       = "A simple and lightweight gem to escalate rescued exceptions."
+  spec.description   = "A simple and lightweight gem to escalate rescued exceptions."
   spec.homepage      = "https://github.com/invoca/escalate"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 

--- a/escalate.gemspec
+++ b/escalate.gemspec
@@ -27,9 +27,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
-
-  # For more information and examples about making a new gem, checkout our
-  # guide at: https://bundler.io/guides/creating_gem.html
+  spec.add_dependency "activesupport"
 end

--- a/escalate.gemspec
+++ b/escalate.gemspec
@@ -28,5 +28,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport"
-  spec.add_dependency "contextual_logger"
 end

--- a/lib/escalate.rb
+++ b/lib/escalate.rb
@@ -57,8 +57,24 @@ module Escalate
 
       Module.new do
         def self.included(base)
-          base.extend Escalate::Mixin
+          base.extend self
           base.escalate_logger_block = Thread.current[:escalate_logger_block] || -> { base.try(:logger) }
+        end
+
+        attr_accessor :escalate_logger_block
+
+        def escalate(exception, message, **context)
+          Escalate.escalate(exception, message, escalate_logger, **context)
+        end
+
+        private
+
+        def escalate_logger
+          escalate_logger_block.try(:call) || default_escalate_logger
+        end
+
+        def default_escalate_logger
+          @default_escalate_logger ||= Logger.new(STDERR)
         end
       end
     end

--- a/lib/escalate.rb
+++ b/lib/escalate.rb
@@ -5,52 +5,60 @@ require "active_support/core_ext"
 require "contextual_logger"
 
 require_relative "escalate/version"
+require_relative "escalate/mixin"
 
 module Escalate
   class Error < StandardError; end
 
   class << self
+    # Logs and escalated an exception
+    #
+    # @param [Exception] exception
+    #   The exception that was raised and needs to be escalated
+    #
+    # @param [String] message
+    #   An additional message about what was happening at the time of the exception
+    #
+    # @param [Logger] logger
+    #   The logger object to use when logging the exception
+    #
+    # @param [Hash] context
+    #   Any additional context to be tied to the escalation
+    def escalate(exception, message, logger, **context)
+      error_message = <<~EOS
+        [Escalate] #{message} (#{context.inspect})
+          #{exception.class.name}: #{exception.message}
+          #{exception.backtrace.join("\n")}
+      EOS
+
+      if logger.is_a?(ContextualLogger::LoggerMixin)
+        logger.error(error_message, **context)
+      else
+        logger.error(error_message)
+      end
+
+      on_escalate_blocks.each do |block|
+        block.call(exception, message, **context)
+      end
+    rescue Exception => ex
+      STDERR.puts("[ExEscalator] Exception rescued while escalating #{exception.inspect}:" \
+                "#{ex.class.name}: #{ex.message}")
+    end
+
     # Returns a module to be mixed into a class or module exposing
     # the ex_escalate method to be used for escalating and logging
     # exceptions.
-    def mixin(&block)
+    #
+    # @param [Proc] logger_block
+    #   A block to be used to get the logger object that Escalate
+    #   should be using
+    def mixin(&logger_block)
+      Thread.current[:escalate_logger_block] = logger_block
+
       Module.new do
-        def ex_escalate(exception, message, **context)
-          error_message = <<~EOS
-            [Escalate] #{message} (#{context.inspect})
-              #{exception.class.name}: #{exception.message}
-              #{exception.backtrace.join("\n")}
-          EOS
-
-          if using_contextual_logger?
-            escalate_logger.error(error_message, **context)
-          else
-            escalate_logger.error(error_message)
-          end
-
-          Escalate.on_escalate_blocks.each do |block|
-            block.call(exception, message, **context)
-          end
-        end
-
-        protected
-
-        if block
-          define_method(:escalate_logger_from_block, &block)
-        else
-          define_method(:escalate_logger_from_block, -> {})
-        end
-
-        def escalate_logger
-          escalate_logger_from_block || self.try(:logger) || default_escalate_logger
-        end
-
-        def default_escalate_logger
-          @default_escalate_logger ||= Logger.new(STDERR)
-        end
-
-        def using_contextual_logger?
-          escalate_logger.is_a?(ContextualLogger::LoggerMixin)
+        def self.included(base)
+          base.extend Escalate::Mixin
+          base.escalate_logger_block = Thread.current[:escalate_logger_block] || -> { base.try(:logger) }
         end
       end
     end
@@ -60,6 +68,8 @@ module Escalate
     def on_escalate(&block)
       on_escalate_blocks.add(block)
     end
+
+    private
 
     def on_escalate_blocks
       @on_escalate_blocks ||= Set.new

--- a/lib/escalate.rb
+++ b/lib/escalate.rb
@@ -70,7 +70,7 @@ module Escalate
         private
 
         def escalate_logger
-          escalate_logger_block.try(:call) || default_escalate_logger
+          escalate_logger_block&.call || default_escalate_logger
         end
 
         def default_escalate_logger

--- a/lib/escalate.rb
+++ b/lib/escalate.rb
@@ -46,7 +46,7 @@ module Escalate
     end
 
     # Returns a module to be mixed into a class or module exposing
-    # the ex_escalate method to be used for escalating and logging
+    # the escalate method to be used for escalating and logging
     # exceptions.
     #
     # @param [Proc] logger_block
@@ -63,7 +63,7 @@ module Escalate
       end
     end
 
-    # Registers an escalation callback to be executed when `ex_escalate`
+    # Registers an escalation callback to be executed when `escalate`
     # is invoked.
     def on_escalate(&block)
       on_escalate_blocks.add(block)

--- a/lib/escalate.rb
+++ b/lib/escalate.rb
@@ -1,8 +1,40 @@
 # frozen_string_literal: true
 
+require "active_support"
+require "active_support/core_ext"
+
 require_relative "escalate/version"
 
 module Escalate
   class Error < StandardError; end
-  # Your code goes here...
+
+  class << self
+    def mixin(&block)
+      Module.new do
+        def ex_escalate(exception, message)
+          escalate_logger.error <<~EOS
+            [Escalate] #{message}
+              #{exception.class.name}: #{exception.message}
+              #{exception.backtrace.join("\n")}
+          EOS
+        end
+
+        protected
+
+        if block
+          define_method(:escalate_logger_from_block, &block)
+        else
+          define_method(:escalate_logger_from_block, -> {})
+        end
+
+        def escalate_logger
+          escalate_logger_from_block || self.try(:logger) || default_escalate_logger
+        end
+
+        def default_escalate_logger
+          @default_escalate_logger ||= Logger.new(STDERR)
+        end
+      end
+    end
+  end
 end

--- a/lib/escalate/mixin.rb
+++ b/lib/escalate/mixin.rb
@@ -4,13 +4,13 @@ module Escalate
   module Mixin
     class << self
       def included(base)
-        raise 'instead of `include ExEscalator::Mixin`, you should `include ExEscalator.mixin`'
+        raise 'instead of `include Escalator::Mixin`, you should `include Escalator.mixin`'
       end
     end
 
     attr_accessor :escalate_logger_block
 
-    def ex_escalate(exception, message, **context)
+    def escalate(exception, message, **context)
       Escalate.escalate(exception, message, escalate_logger, **context)
     end
 

--- a/lib/escalate/mixin.rb
+++ b/lib/escalate/mixin.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Escalate
+  module Mixin
+    class << self
+      def included(base)
+        raise 'instead of `include ExEscalator::Mixin`, you should `include ExEscalator.mixin`'
+      end
+    end
+
+    attr_accessor :escalate_logger_block
+
+    def ex_escalate(exception, message, **context)
+      Escalate.escalate(exception, message, escalate_logger, **context)
+    end
+
+    private
+
+    def escalate_logger
+      escalate_logger_block.try(:call) || default_escalate_logger
+    end
+
+    def default_escalate_logger
+      @default_escalate_logger ||= Logger.new(STDERR)
+    end
+  end
+end

--- a/lib/escalate/mixin.rb
+++ b/lib/escalate/mixin.rb
@@ -4,24 +4,8 @@ module Escalate
   module Mixin
     class << self
       def included(base)
-        raise 'instead of `include Escalator::Mixin`, you should `include Escalator.mixin`'
+        raise 'instead of `include Escalate::Mixin`, you should `include Escalate.mixin`'
       end
-    end
-
-    attr_accessor :escalate_logger_block
-
-    def escalate(exception, message, **context)
-      Escalate.escalate(exception, message, escalate_logger, **context)
-    end
-
-    private
-
-    def escalate_logger
-      escalate_logger_block.try(:call) || default_escalate_logger
-    end
-
-    def default_escalate_logger
-      @default_escalate_logger ||= Logger.new(STDERR)
     end
   end
 end

--- a/lib/escalate/version.rb
+++ b/lib/escalate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Escalate
-  VERSION = "0.1.0.pre.1"
+  VERSION = "0.1.0.pre.2"
 end

--- a/lib/escalate/version.rb
+++ b/lib/escalate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Escalate
-  VERSION = "0.1.0"
+  VERSION = "0.1.0.pre.1"
 end

--- a/spec/escalate_spec.rb
+++ b/spec/escalate_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class TestEscalateGemWithDefaultLogger
-  extend Escalate.mixin
+  include Escalate.mixin
 end
 
 class TestEscalateGemWithLogger
-  extend Escalate.mixin
+  include Escalate.mixin
 
   class << self
     def logger
@@ -15,7 +15,7 @@ class TestEscalateGemWithLogger
 end
 
 class TestEscalateGemWithBlock
-  extend Escalate.mixin { some_other_logger }
+  include Escalate.mixin { some_other_logger }
 
   class << self
     def some_other_logger

--- a/spec/escalate_spec.rb
+++ b/spec/escalate_spec.rb
@@ -1,7 +1,65 @@
 # frozen_string_literal: true
 
+class TestEscalateGemWithDefaultLogger
+  extend Escalate.mixin
+end
+
+class TestEscalateGemWithLogger
+  extend Escalate.mixin
+
+  class << self
+    def logger
+      @logger ||= Logger.new(STDOUT)
+    end
+  end
+end
+
+class TestEscalateGemWithBlock
+  extend Escalate.mixin { some_other_logger }
+
+  class << self
+    def some_other_logger
+      @some_other_logger ||= Logger.new(STDOUT)
+    end
+  end
+end
+
 RSpec.describe Escalate do
   it "has a version number" do
     expect(Escalate::VERSION).not_to be nil
+  end
+
+  describe "#mixin" do
+    let(:exception) {
+      begin
+        raise 'oops'
+      rescue => ex
+        ex
+      end
+    }
+
+    subject { described_class.mixin }
+    it { should be_a(Module) }
+
+    context "when there is not logger" do
+      it 'uses a default logger' do
+        expect(TestEscalateGemWithDefaultLogger.send(:default_escalate_logger)).to receive(:error)
+        TestEscalateGemWithDefaultLogger.ex_escalate(exception, "I was doing something and got this exception")
+      end
+    end
+
+    context "when self.logger exists" do
+      it 'uses the logger returned by the logger method' do
+        expect(TestEscalateGemWithLogger.logger).to receive(:error)
+        TestEscalateGemWithLogger.ex_escalate(exception, "I was doing something and got this exception")
+      end
+    end
+
+    context "when a block is passed to the mixin" do
+      it 'uses the logger returned by the block' do
+        expect(TestEscalateGemWithBlock.some_other_logger).to receive(:error)
+        TestEscalateGemWithBlock.ex_escalate(exception, "I was doing something and got this exception")
+      end
+    end
   end
 end

--- a/spec/escalate_spec.rb
+++ b/spec/escalate_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'contextual_logger'
+
 class TestEscalateGemWithDefaultLogger
   include Escalate.mixin
 end

--- a/spec/escalate_spec.rb
+++ b/spec/escalate_spec.rb
@@ -48,26 +48,26 @@ RSpec.describe Escalate do
     context "when there is not logger" do
       it 'uses a default logger' do
         expect(TestEscalateGemWithDefaultLogger.send(:default_escalate_logger)).to receive(:error)
-        TestEscalateGemWithDefaultLogger.ex_escalate(exception, "I was doing something and got this exception")
+        TestEscalateGemWithDefaultLogger.escalate(exception, "I was doing something and got this exception")
       end
     end
 
     context "when self.logger exists" do
       it 'uses the logger returned by the logger method' do
         expect(TestEscalateGemWithLogger.logger).to receive(:error)
-        TestEscalateGemWithLogger.ex_escalate(exception, "I was doing something and got this exception")
+        TestEscalateGemWithLogger.escalate(exception, "I was doing something and got this exception")
       end
     end
 
     context "when a block is passed to the mixin" do
       it 'uses the logger returned by the block' do
         expect(TestEscalateGemWithBlock.some_other_logger).to receive(:error)
-        TestEscalateGemWithBlock.ex_escalate(exception, "I was doing something and got this exception")
+        TestEscalateGemWithBlock.escalate(exception, "I was doing something and got this exception")
       end
     end
   end
 
-  describe "#ex_escalate" do
+  describe "#escalate" do
     context "when context is passed" do
       let(:log_context) { { hello: "world", more: "context" } }
       let(:log_message) { "[Escalate] I was doing something and got this exception (#{log_context.inspect})\n  #{exception.class.name}: #{exception.message}\n  #{exception.backtrace.join("\n")}\n" }
@@ -88,7 +88,7 @@ RSpec.describe Escalate do
 
         it 'includes the provided context in the json log entry' do
           expect do
-            TestEscalateGemWithLogger.ex_escalate(exception, "I was doing something and got this exception", hello: "world", more: "context")
+            TestEscalateGemWithLogger.escalate(exception, "I was doing something and got this exception", hello: "world", more: "context")
           end.to output("#{expected_log_line}\n").to_stdout_from_any_process
         end
       end
@@ -106,12 +106,12 @@ RSpec.describe Escalate do
       expect(described_class.send(:on_escalate_blocks)).to include(callback)
     end
 
-    context 'when ex_escalate is called' do
+    context 'when escalate is called' do
       before { allow(TestEscalateGemWithLogger).to receive(:logger).and_return(Logger.new('/dev/null')) }
 
       it 'executes the callback' do
         expect(callback).to receive(:call).with(exception, "I was doing something and got this exception", hello: "world", more: "context")
-        TestEscalateGemWithLogger.ex_escalate(exception, "I was doing something and got this exception", hello: "world", more: "context")
+        TestEscalateGemWithLogger.escalate(exception, "I was doing something and got this exception", hello: "world", more: "context")
       end
     end
   end

--- a/spec/escalate_spec.rb
+++ b/spec/escalate_spec.rb
@@ -94,4 +94,25 @@ RSpec.describe Escalate do
       end
     end
   end
+
+  describe "#on_escalate" do
+    let(:callback) do
+      -> (exception, message, **context) { }
+    end
+
+    before { described_class.on_escalate(&callback) }
+
+    it 'registers the block provided' do
+      expect(described_class.send(:on_escalate_blocks)).to include(callback)
+    end
+
+    context 'when ex_escalate is called' do
+      before { allow(TestEscalateGemWithLogger).to receive(:logger).and_return(Logger.new('/dev/null')) }
+
+      it 'executes the callback' do
+        expect(callback).to receive(:call).with(exception, "I was doing something and got this exception", hello: "world", more: "context")
+        TestEscalateGemWithLogger.ex_escalate(exception, "I was doing something and got this exception", hello: "world", more: "context")
+      end
+    end
+  end
 end

--- a/spec/escalate_spec.rb
+++ b/spec/escalate_spec.rb
@@ -25,19 +25,23 @@ class TestEscalateGemWithBlock
 end
 
 RSpec.describe Escalate do
+  let(:exception) {
+    begin
+      raise 'oops'
+    rescue => ex
+      ex
+    end
+  }
+
+  before do
+    allow(Time).to receive(:now).and_return(Time.parse("2021-02-01"))
+  end
+
   it "has a version number" do
     expect(Escalate::VERSION).not_to be nil
   end
 
   describe "#mixin" do
-    let(:exception) {
-      begin
-        raise 'oops'
-      rescue => ex
-        ex
-      end
-    }
-
     subject { described_class.mixin }
     it { should be_a(Module) }
 
@@ -59,6 +63,34 @@ RSpec.describe Escalate do
       it 'uses the logger returned by the block' do
         expect(TestEscalateGemWithBlock.some_other_logger).to receive(:error)
         TestEscalateGemWithBlock.ex_escalate(exception, "I was doing something and got this exception")
+      end
+    end
+  end
+
+  describe "#ex_escalate" do
+    context "when context is passed" do
+      let(:log_context) { { hello: "world", more: "context" } }
+      let(:log_message) { "[Escalate] I was doing something and got this exception (#{log_context.inspect})\n  #{exception.class.name}: #{exception.message}\n  #{exception.backtrace.join("\n")}\n" }
+
+      before { allow(TestEscalateGemWithLogger).to receive(:logger).and_return(logger) }
+
+      context "when the logger extends ContextualLogger" do
+        let(:logger) { Logger.new(STDOUT).tap { |log| log.extend ContextualLogger::LoggerMixin } }
+        let(:expected_log_line) do
+          {
+            message: log_message,
+            severity: "ERROR",
+            timestamp: Time.now,
+            hello: "world",
+            more: "context"
+          }.to_json
+        end
+
+        it 'includes the provided context in the json log entry' do
+          expect do
+            TestEscalateGemWithLogger.ex_escalate(exception, "I was doing something and got this exception", hello: "world", more: "context")
+          end.to output("#{expected_log_line}\n").to_stdout_from_any_process
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,9 @@
 require "escalate"
 
 RSpec.configure do |config|
+  if config.files_to_run.one?
+    config.default_formatter = 'doc'
+  end
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 
@@ -11,5 +14,10 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+    c.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
   end
 end


### PR DESCRIPTION
This creates the initial interface for the gem, allowing you to use `include Escalate.mixin` and `ex_escalate` from within your gem