### PR TITLE
TECH-5214: use escalate in exception_handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - Unreleased
+## [0.2.0] - 2021-03-02
 ### Added
 - Added support for `on_escalate(log_first: false)`. The `escalate` gem will log first before
   escalating if either of these is true: there are no `on_escalate` blocks registered, or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - Unreleased
+### Added
+- Added support for `on_escalate(log_first: false)`. The `escalate` gem will log first before
+  escalating if either of these is true: there are no `on_escalate` blocks registered, or
+  there are some and at least one of them passed `log_first: false`.
+
 ## [0.1.0] - 2021-02-03
 ### Added
 - Added `Escalate.mixin` interface for mixing in `Escalate` with your module for easy escalation of rescued exceptions
 - Added `escalate` method for escalating rescued exceptions with default behavior of logging to `STDERR`
 - Added `Escalate.on_escalate` for registering escalation callbacks like `Honeybadger` or `Sentry`
 
+[0.2.0]: https://github.com/Invoca/escalate/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Invoca/escalate/releases/tag/v0.1.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    escalate (0.1.0)
+    escalate (0.2.0.pre.1)
       activesupport
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    escalate (0.2.0.pre.1)
+    escalate (0.2.0.pre.2)
       activesupport
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
       thread_safe (~> 0.1)
 
 PLATFORMS
+  ruby
   x86_64-darwin-19
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    escalate (0.2.0.pre.2)
+    escalate (0.2.0.pre.3)
       activesupport
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    escalate (0.2.0.pre.4)
+    escalate (0.2.0)
       activesupport
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    escalate (0.2.0.pre.3)
+    escalate (0.2.0.pre.4)
       activesupport
 
 GEM

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ Escalate.on_escalate do |exception, location_message, **context|
 end
 ```
 
+#### Callback Uniqueness
+Each callback may be named with the `name:` keyword argument.
+If a callback with the same name has been registered before, it will be overwritten with the new one.
+```
+Escalate.on_escalate(name: 'abc gem') do |exception, location_message, **context|
+  # send exception, location_message, **context to the error reporting service here
+end
+```
+If not given, the `name:` defaults to the `.source_location` property of the passed-in block.
+
 #### Handle the Logging in the `on_escalate` Callback
 Here is an example that handles logging itself with `log_first: false`:
 ```

--- a/README.md
+++ b/README.md
@@ -58,8 +58,34 @@ end
 When `SomeGem.escalate` above is triggered, it will use the logger returned by `SomeGem.logger` or
 default to a `STDERR` logger and do the following:
 
-1. Log an error containing the exception and any additional information about the current environment that is specified
-2. Trigger any `escalation_callbacks` configured on the `Escalate` gem
+1. [optional] Log an error containing the exception, location_message, and context hash
+2. Trigger any `on_escalate_callbacks` configured on the `Escalate` gem
+
+Step (1) is optional. It will happen if either of these is true:
+ - by default if no `on_escalate_callbacks` have been registered; or
+ - if any of the `on_escalate_callbacks` was registered with `on_escalate(log_first: true)`.
+
+### Registering an Escalate Callback
+
+If you are using an error reporting service, you can register an `on_escalate` callback to escalate exceptions.
+You have the option to handle logging yourself, or to let `escalate` log first, before calling your callback.
+
+#### Leave the Logging to the Escalate Gem
+Here is an example that uses the default `log_first: true` so that logging is handled by the `Escalate` gem first:
+```
+Escalate.on_escalate do |exception, location_message, **context|
+  # send exception, location_message, **context to the error reporting service here
+end
+```
+
+#### Handle the Logging in the `on_escalate` Callback
+Here is an example that handles logging itself with `log_first: false`:
+```
+Escalate.on_escalate(log_first: false) do |exception, location_message, **context|
+  # log here first
+  # send exception, location_message, **context to the error reporting service here
+end
+```
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/escalate.rb
+++ b/lib/escalate.rb
@@ -32,16 +32,17 @@ module Escalate
     def escalate(exception, location_message, logger, **context)
       ensure_failsafe("Exception rescued while escalating #{exception.inspect}") do
         if on_escalate_callbacks.none? || on_escalate_callbacks.any? { |block| block.instance_variable_get(LOG_FIRST_INSTANCE_VARIABLE) }
+          logger_allows_added_context?(logger) or context_string = " (#{context.inspect})"
           error_message = <<~EOS
-            [Escalate] #{location_message} (#{context.inspect})
+            [Escalate] #{location_message}#{context_string}
             #{exception.class.name}: #{exception.message}
             #{exception.backtrace.join("\n")}
           EOS
 
-          if logger_allows_added_context?(logger)
-            logger.error(error_message, **context)
-          else
+          if context_string
             logger.error(error_message)
+          else
+            logger.error(error_message, **context)
           end
         end
 

--- a/lib/escalate/version.rb
+++ b/lib/escalate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Escalate
-  VERSION = "0.1.0"
+  VERSION = "0.2.0.pre.1"
 end

--- a/lib/escalate/version.rb
+++ b/lib/escalate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Escalate
-  VERSION = "0.2.0.pre.2"
+  VERSION = "0.2.0.pre.3"
 end

--- a/lib/escalate/version.rb
+++ b/lib/escalate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Escalate
-  VERSION = "0.2.0.pre.4"
+  VERSION = "0.2.0"
 end

--- a/lib/escalate/version.rb
+++ b/lib/escalate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Escalate
-  VERSION = "0.2.0.pre.3"
+  VERSION = "0.2.0.pre.4"
 end

--- a/lib/escalate/version.rb
+++ b/lib/escalate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Escalate
-  VERSION = "0.2.0.pre.1"
+  VERSION = "0.2.0.pre.2"
 end

--- a/spec/escalate_spec.rb
+++ b/spec/escalate_spec.rb
@@ -37,11 +37,11 @@ RSpec.describe Escalate do
 
   before do
     allow(Time).to receive(:now).and_return(Time.parse("2021-02-01"))
-    Escalate.clear_all_on_escalate_blocks
+    Escalate.clear_on_escalate_callbacks
   end
 
   after do
-    Escalate.clear_all_on_escalate_blocks
+    Escalate.clear_on_escalate_callbacks
   end
 
   it "has a version number" do
@@ -140,8 +140,7 @@ RSpec.describe Escalate do
       before { described_class.on_escalate(log_first: false, &callback) }
 
       it 'registers the block provided' do
-        expect(described_class.send(:on_escalate_blocks)).to be_empty
-        expect(described_class.send(:on_escalate_no_log_first_blocks)).to include(callback)
+        expect(described_class.send(:on_escalate_blocks)).to include(callback)
       end
 
       context 'when escalate is called' do

--- a/spec/escalate_spec.rb
+++ b/spec/escalate_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Escalate do
   describe "#escalate" do
     context "when context is passed" do
       let(:log_context) { { hello: "world", more: "context" } }
-      let(:log_message) { "[Escalate] I was doing something and got this exception (#{log_context.inspect})\n#{exception.class.name}: #{exception.message}\n#{exception.backtrace.join("\n")}\n" }
+      let(:log_message) { "[Escalate] I was doing something and got this exception\n#{exception.class.name}: #{exception.message}\n#{exception.backtrace.join("\n")}\n" }
 
       before { allow(TestEscalateGemWithLogger).to receive(:logger).and_return(logger) }
 
@@ -97,6 +97,18 @@ RSpec.describe Escalate do
           expect do
             TestEscalateGemWithLogger.escalate(exception, "I was doing something and got this exception", hello: "world", more: "context")
           end.to output("#{expected_log_line}\n").to_stdout_from_any_process
+        end
+      end
+
+      context "when the logger doesn't extend ContextualLogger" do
+        let(:logger) { Logger.new(STDOUT) }
+        let(:log_message) { "[Escalate] I was doing something and got this exception ({:hello=>\"world\", :more=>\"context\"})" }
+        let(:expected_log_line) { /#{Regexp.escape(log_message)}/ }
+
+        it 'includes the provided context at the end of the message' do
+          expect do
+            TestEscalateGemWithLogger.escalate(exception, "I was doing something and got this exception", hello: "world", more: "context")
+          end.to output(expected_log_line).to_stdout_from_any_process
         end
       end
     end

--- a/spec/escalate_spec.rb
+++ b/spec/escalate_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Escalate do
       before { described_class.on_escalate(&callback) }
 
       it 'registers the block provided' do
-        expect(described_class.send(:on_escalate_blocks)).to include(callback)
+        expect(described_class.on_escalate_callbacks).to include(callback)
       end
 
       context 'when escalate is called' do
@@ -132,7 +132,7 @@ RSpec.describe Escalate do
       before { described_class.on_escalate(log_first: true, &callback) }
 
       it 'registers the block provided' do
-        expect(described_class.send(:on_escalate_blocks)).to include(callback)
+        expect(described_class.on_escalate_callbacks).to include(callback)
       end
     end
 
@@ -140,7 +140,7 @@ RSpec.describe Escalate do
       before { described_class.on_escalate(log_first: false, &callback) }
 
       it 'registers the block provided' do
-        expect(described_class.send(:on_escalate_blocks)).to include(callback)
+        expect(described_class.on_escalate_callbacks).to include(callback)
       end
 
       context 'when escalate is called' do

--- a/spec/escalate_spec.rb
+++ b/spec/escalate_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Escalate do
       before { described_class.on_escalate(&callback) }
 
       it 'registers the block provided' do
-        expect(described_class.on_escalate_callbacks).to include(callback)
+        expect(described_class.on_escalate_callbacks.values).to include(callback)
       end
 
       context 'when escalate is called' do
@@ -144,7 +144,7 @@ RSpec.describe Escalate do
       before { described_class.on_escalate(log_first: true, &callback) }
 
       it 'registers the block provided' do
-        expect(described_class.on_escalate_callbacks).to include(callback)
+        expect(described_class.on_escalate_callbacks.values).to include(callback)
       end
     end
 
@@ -152,7 +152,7 @@ RSpec.describe Escalate do
       before { described_class.on_escalate(log_first: false, &callback) }
 
       it 'registers the block provided' do
-        expect(described_class.on_escalate_callbacks).to include(callback)
+        expect(described_class.on_escalate_callbacks.values).to include(callback)
       end
 
       context 'when escalate is called' do
@@ -166,6 +166,25 @@ RSpec.describe Escalate do
           expect(callback).to receive(:call).with(exception, "I was doing something and got this exception", hello: "world", more: "context")
           TestEscalateGemWithLogger.escalate(exception, "I was doing something and got this exception", hello: "world", more: "context")
         end
+      end
+    end
+
+    describe 'name:' do
+      it 'uniques on name:' do
+        expect(described_class.on_escalate_callbacks.size).to eq(0)
+        described_class.on_escalate(name: 'abc', &callback)
+        expect(described_class.on_escalate_callbacks.size).to eq(1)
+        described_class.on_escalate(name: 'abc') { }
+        expect(described_class.on_escalate_callbacks.size).to eq(1)
+      end
+
+      it 'defaults name: to .source_location' do
+        expect(described_class.on_escalate_callbacks.size).to eq(0)
+        expect(callback).to receive(:source_location) { ['a.rb', 3] }.twice
+        described_class.on_escalate(&callback)
+        expect(described_class.on_escalate_callbacks.size).to eq(1)
+        described_class.on_escalate(&callback)
+        expect(described_class.on_escalate_callbacks.size).to eq(1)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,4 +20,6 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
+
+  RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = 2_000
 end


### PR DESCRIPTION
## [0.2.0] - Unreleased
### Added
- Added support for `on_escalate(log_first: false)`. The `escalate` gem will log first before
  escalating if either of these is true: there are no `on_escalate` blocks registered, or
  there are some and at least one of them passed `log_first: false`.